### PR TITLE
fix: clear signature state when transactions are deleted and reproposed

### DIFF
--- a/test/SafeTxPoolGuard.t.sol
+++ b/test/SafeTxPoolGuard.t.sol
@@ -77,7 +77,7 @@ contract SafeTxPoolGuardTest is Test {
         assertEq(pendingTxs.length, 0);
 
         // Verify transaction data is deleted
-        (address txSafe,,,,, address txProposer,) = pool.getTxDetails(txHash);
+        (address txSafe,,,,, address txProposer,,) = pool.getTxDetails(txHash);
         assertEq(txProposer, address(0));
         assertEq(txSafe, address(0));
     }


### PR DESCRIPTION
This commit addresses an issue where the signature state persisted when a
transaction was deleted and later reproposed with the same txHash. The fix:

1. Adds a transaction ID (txId) counter to uniquely identify each transaction
2. Moves signature tracking to a separate mapping based on txHash + txId
3. Ensures transactions with the same hash can't be proposed in parallel
   (must delete first)

This ensures users can properly sign transactions after deletion and reproposal
without encountering 'AlreadySigned' errors.