### PR TITLE
Add GuardNotSuccess event for debugging failed transactions

### DIFF
--- a/src/SafeTxPoolRegistry.sol
+++ b/src/SafeTxPoolRegistry.sol
@@ -306,6 +306,9 @@ contract SafeTxPoolRegistry is BaseGuard {
         transactionValidator.validateTransaction(safe, to, value, data, operation);
     }
 
+    // Events for debugging guard execution
+    event GuardNotSuccess(bytes32 indexed txHash, address indexed safe);
+
     /**
      * @notice Implementation of the Guard interface's checkAfterExecution function
      * @dev This function is called after a Safe transaction is executed
@@ -314,7 +317,10 @@ contract SafeTxPoolRegistry is BaseGuard {
      */
     function checkAfterExecution(bytes32 txHash, bool success) external override {
         // Only proceed if transaction was successful
-        if (!success) return;
+        if (!success) {
+            emit GuardNotSuccess(txHash, msg.sender);
+            return;
+        }
 
         // Since the transaction hash is the same in the pool and in the Safe,
         // we can directly try to mark the transaction as executed

--- a/src/SafeTxPoolRegistry.sol
+++ b/src/SafeTxPoolRegistry.sol
@@ -307,7 +307,7 @@ contract SafeTxPoolRegistry is BaseGuard {
     }
 
     // Events for debugging guard execution
-    event GuardNotSuccess(bytes32 indexed txHash, address indexed safe);
+    event GuardAfterExecuted(bytes32 indexed txHash, address indexed safe, bool success);
 
     /**
      * @notice Implementation of the Guard interface's checkAfterExecution function
@@ -316,11 +316,11 @@ contract SafeTxPoolRegistry is BaseGuard {
      * @param success Whether the transaction was successful
      */
     function checkAfterExecution(bytes32 txHash, bool success) external override {
+        // Always emit event at the beginning to track guard execution
+        emit GuardAfterExecuted(txHash, msg.sender, success);
+
         // Only proceed if transaction was successful
-        if (!success) {
-            emit GuardNotSuccess(txHash, msg.sender);
-            return;
-        }
+        if (!success) return;
 
         // Since the transaction hash is the same in the pool and in the Safe,
         // we can directly try to mark the transaction as executed


### PR DESCRIPTION
## Problem

We discovered that the `TransactionRemovedFromPending` event is not being emitted in some cases on the deployed contracts. Through investigation, we found that this could be due to:

1. **Out of gas issues** - The guard's `checkAfterExecution` function runs out of gas
2. **Failed transactions** - The Safe transaction fails but the guard is still called with `success=false`
3. **Transaction not in pool** - The transaction doesn't exist in the pool when `markAsExecuted` is called

## Solution

Added a simple `GuardNotSuccess` event that is emitted when `checkAfterExecution` is called with `success=false`. This helps distinguish between different failure scenarios:

- **No events at all** → Guard ran out of gas or wasn't called
- **GuardNotSuccess event** → Transaction failed, guard was called but didn't attempt `markAsExecuted`
- **TransactionRemovedFromPending event** → Everything worked correctly

## Changes

- Added `GuardNotSuccess(bytes32 indexed txHash, address indexed safe)` event
- Modified `checkAfterExecution` to emit this event when `success=false`
- Simple, clean implementation suitable for production debugging

## Testing

The changes maintain backward compatibility and only add debugging capability. All existing functionality remains unchanged.

## Impact

This will help diagnose the root cause of missing `TransactionRemovedFromPending` events in production by providing visibility into failed transaction scenarios.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author